### PR TITLE
Fix tRPC type imports from api working in web.

### DIFF
--- a/apps/api/tsconfig.types.json
+++ b/apps/api/tsconfig.types.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  },
+  "paths": {
+    "src/*": ["src/*"]
+  },
+  "include": ["src/"],
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/apps/web/src/utils/trpc.ts
+++ b/apps/web/src/utils/trpc.ts
@@ -1,5 +1,21 @@
 import { createTRPCReact } from "@trpc/react-query";
-//Fixme: Import from shared package
-import type { AppRouter } from "../../../api/src/trpc/routers";
+
+/* Here we import the AppRouter type directly from the api package.
+ * This would usually be a bad thing to do, but we are only importing the type
+ * and not the implementation, so this will not affect the build, only type checking in local dev.
+ *
+ * This works as `tsconfig.app.json` has a project reference to `apps/api/tsconfig.types.json`,
+ * allowing path imports from source files in the api project to work.
+ * E.g. A source file importing from `src/trpc/routers` will correctly resolve the path alias src,
+ * as mentioned in the tsconfig.types.json file.
+ *
+ * We also have a `@api/*` path alias in the tsconfig.json file, which allows us to import from the
+ * api package a little more cleanly here.
+ *
+ * However, we should never use this method to import anything except for types,
+ * as it will break the build!
+ */
+
+import type { AppRouter } from "@api/trpc/routers";
 
 export const trpc = createTRPCReact<AppRouter>();

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -20,7 +20,11 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "paths": {
+      "@api/*": ["../api/src/*"]
+    }
   },
+  "references": [{ "path": "../api/tsconfig.types.json" }],
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
Fix type imports from API package in web project using [typescript project references](https://www.typescriptlang.org/docs/handbook/project-references.html).

## Problem
The web project needs to import types from the API project for tRPC router type inference to work correctly. Previously, we were importing these types directly from the API source files, which caused TypeScript compilation errors like:

```
 $ yarn workspace web build
yarn workspace v1.22.22
yarn run v1.22.22
$ tsc -b && vite build
../api/src/trpc/trpc.ts:3:31 - error TS2307: Cannot find module 'src/services/services.module' or its corresponding type declarations.

3 import type { Services } from 'src/services/services.module';
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This error occurred because the type checker is running in the `web` project, but referencing code in the `api` project, and the `api` project has a path alias set up so that `/src/*` correctly resolves to `/apps/api/src/*`.
However this alias does not exist in the `web` project, causing path resolution to fail.

## Solution

Added TypeScript project references to handle type imports from the API package:

1. Created a new `tsconfig.types.json` in the API project that:
   - Enables declaration file generation (`declaration: true`)
   - Only emits type declarations (`emitDeclarationOnly: true`)
   - Preserves the API project's path aliases

2. Added a project reference in `web/tsconfig.app.json` pointing to `api/tsconfig.types.json`
3. Configured a path alias `@api/*` in the web project to cleanly import from API sources

This setup allows us to safely import types from the API project while:
- Maintaining proper project boundaries
- Preserving path resolution across projects
- Only importing types, not implementation code (which would break the build)

The changes enable proper type checking for tRPC router types in the web project, which is essential for maintaining type safety across our frontend-backend boundary.

## Note

While directly importing from another project's source files is generally discouraged, this is a valid exception since:
1. We only import types, not implementation code (only affects type checking stage, not output)
2. Type information from the API is required for tRPC's type inference to work
3. The project references setup ensures this is done in a TypeScript-safe way
