### PR TITLE
Secure HTTP headers with Helmet

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -39,6 +39,7 @@
     "drizzle-kit": "^0.30.1",
     "drizzle-orm": "^0.38.2",
     "express": "^4.21.2",
+    "helmet": "^8.0.0",
     "postgres": "^3.4.5",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^5.0.1",

--- a/apps/backend/src/entrypoints/api/main.ts
+++ b/apps/backend/src/entrypoints/api/main.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import helmet from 'helmet';
 
 declare const module: any;
 async function bootstrap() {
@@ -11,6 +12,9 @@ async function bootstrap() {
         snapshot: process.env.NODE_ENV !== 'production',
       });
       app.enableCors();
+
+      // Secure HTTP headers - defualt settings
+      app.use(helmet());
     
       const config = new DocumentBuilder()
         .setTitle('Example API')

--- a/apps/backend/src/entrypoints/reactSSR/main.ts
+++ b/apps/backend/src/entrypoints/reactSSR/main.ts
@@ -1,15 +1,30 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import helmet from 'helmet';
 
 declare const module: any;
 async function bootstrap() {
   const logger = new Logger('EntryPoint [ReactSSR]');
   const app = await NestFactory.create(AppModule);
+
   app.enableCors();
+  // See https://helmetjs.github.io/ for more info on settings
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          'default-src': ["'self'"],
+          'script-src': ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+          'style-src': ["'self'", "'unsafe-inline'"],
+          'img-src': ["'self'", 'data:', 'https:'],
+          'connect-src': ["'self'", 'http://localhost:*', 'ws://localhost:*'],
+        },
+      },
+    }),
+  );
 
   const PORT = 3000;
-
   await app.listen(PORT);
 
   if (module.hot) {

--- a/apps/backend/src/entrypoints/reactStatic/main.ts
+++ b/apps/backend/src/entrypoints/reactStatic/main.ts
@@ -1,13 +1,29 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import helmet from 'helmet';
 
 declare const module: any;
 async function bootstrap() {
   const logger = new Logger('EntryPoint [ReactStatic]');
   const app = await NestFactory.create(AppModule);
-  app.enableCors();
 
+  app.enableCors();
+  // Secure HTTP headers - defualt settings
+  // See https://helmetjs.github.io/ for more info on settings
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          'default-src': ["'self'"],
+          'script-src': ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+          'style-src': ["'self'", "'unsafe-inline'"],
+          'img-src': ["'self'", 'data:', 'https:'],
+          'connect-src': ["'self'", 'http://localhost:*', 'ws://localhost:*'],
+        },
+      },
+    }),
+  );
   const PORT = 3000;
 
   await app.listen(PORT);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,6 +3766,11 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+helmet@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.0.0.tgz#05370fb1953aa7b81bd0ddfa459221247be6ea5c"
+  integrity sha512-VyusHLEIIO5mjQPUI1wpOAEu+wl6Q0998jzTxqUYGE45xCIcAxy3MsbEK/yyJUJ3ADeMoB6MornPH6GMWAf+Pw==
+
 hexoid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"


### PR DESCRIPTION
## Summary

Use [Helmet](https://github.com/helmetjs/helmet) to provide secure by default HTTP response headers in the backend.

Some settings may need updating if we have issues.
